### PR TITLE
Initial setup for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: go
+
+go:
+  - 1.13.x
+
+env:
+  global:
+    - GO111MODULE=on
+
+stages:
+  - test
+  - build
+  - name: push
+    if: fork = false
+
+jobs:
+  include:
+    - stage: test
+      script:
+        - make travis-setup
+        - make test
+    - stage: build
+      script:
+        - make travis-setup
+        - export TAG=$(git rev-parse --short $TRAVIS_COMMIT)
+        - make docker-build IMG=quay.io/slrz/synapse-operator:$TAG
+    - stage: push
+      script:
+        - make travis-setup
+        - export TAG=$(git rev-parse --short $TRAVIS_COMMIT)
+        - docker login --password "$QUAY_PASSWORD" --username "$QUAY_USERNAME" quay.io
+        - make docker-build docker-push IMG=quay.io/slrz/synapse-operator:$TAG

--- a/Makefile
+++ b/Makefile
@@ -115,3 +115,9 @@ bundle: manifests
 # Build the bundle image.
 bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+# Download and install kubebuilder (required for running tests)
+travis-setup:
+	curl -sLo kubebuilder.tar.gz https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz
+	tar --xform='s/kubebuilder_2.3.1_linux_amd64/kubebuilder/' -xf kubebuilder.tar.gz && rm -f kubebuilder.tar.gz
+	sudo mv kubebuilder /usr/local/


### PR DESCRIPTION
Add an initial Travis config to run tests, build container images and push them to Quay.