### PR TITLE
Allow users to specify alternate container image in the CR

### DIFF
--- a/api/v1alpha1/synapse_types.go
+++ b/api/v1alpha1/synapse_types.go
@@ -32,6 +32,12 @@ type SynapseSpec struct {
 
 	// ReportStats enables anonymous statistics reporting
 	ReportStats bool `json:"reportStats"`
+
+	// Image specifies the container image used for running Synapse.
+	// Defaults to "docker.io/matrixdotorg/synapse:latest" if not
+	// specified.
+	// +optional
+	Image string `json:"image,omitempty"`
 }
 
 // SynapseStatus defines the observed state of Synapse

--- a/config/crd/bases/matrix.slrz.net_synapsis.yaml
+++ b/config/crd/bases/matrix.slrz.net_synapsis.yaml
@@ -36,6 +36,10 @@ spec:
         spec:
           description: SynapseSpec defines the desired state of Synapse
           properties:
+            image:
+              description: Image specifies the container image used for running Synapse.
+                Defaults to "docker.io/matrixdotorg/synapse:latest" if not specified.
+              type: string
             reportStats:
               description: ReportStats enables anonymous statistics reporting
               type: boolean


### PR DESCRIPTION
Make the Synapse container image configurable. Default to `docker.io/matrixdotorg/synapse:latest`.